### PR TITLE
feat: add placeholder param

### DIFF
--- a/src/SearchModal.tsx
+++ b/src/SearchModal.tsx
@@ -1,47 +1,15 @@
-import React, {
-  forwardRef,
-  ForwardedRef,
-  useEffect,
-  useRef,
-  ChangeEvent,
-  KeyboardEvent as ReactKeyboardEvent,
-} from "react";
-import { SearchInput } from "./SearchInput";
-import {
-  VuiFlexContainer,
-  VuiFlexItem,
-  VuiLinkInternal,
-  VuiPortal,
-  VuiScreenBlock,
-  VuiSpacer,
-  VuiText,
-  VuiTextColor,
-} from "./vui";
+import { forwardRef, ForwardedRef, useEffect, useRef, ReactNode } from "react";
+import { VuiPortal, VuiScreenBlock } from "./vui";
 import { FocusOn } from "react-focus-on";
 
 type Props = {
-  isLoading: boolean;
-  searchValue?: string;
-  onChange: (evt: ChangeEvent<HTMLInputElement>) => void;
-  onKeyDown: (evt: ReactKeyboardEvent) => void;
   onClose: () => void;
-  resultsList: React.ReactNode;
   isOpen?: boolean;
+  children?: ReactNode[];
 };
 
 export const SearchModal = forwardRef(
-  (
-    {
-      isLoading,
-      searchValue,
-      onChange,
-      onKeyDown,
-      onClose,
-      isOpen,
-      resultsList,
-    }: Props,
-    ref: ForwardedRef<HTMLDivElement>
-  ) => {
+  ({ onClose, isOpen, children }: Props, ref: ForwardedRef<HTMLDivElement>) => {
     const returnFocusElRef = useRef<HTMLElement | null>(null);
 
     // Return focus on unmount.
@@ -77,56 +45,7 @@ export const SearchModal = forwardRef(
               >
                 <div className="searchModalContainer">
                   <div ref={ref} className="searchModal">
-                    <SearchInput
-                      isLoading={isLoading}
-                      value={searchValue}
-                      onChange={onChange}
-                      onKeyDown={onKeyDown}
-                      placeholder="Search docs"
-                    />
-
-                    {resultsList && (
-                      <div className="searchModalResults">{resultsList}</div>
-                    )}
-
-                    <div className="searchModalFooter">
-                      <VuiSpacer size="xs" />
-
-                      <VuiFlexContainer
-                        alignItems="center"
-                        justifyContent="spaceBetween"
-                      >
-                        <VuiFlexItem>
-                          <VuiText size="s" align="right">
-                            <p>
-                              <strong>
-                                <VuiTextColor color="subdued">
-                                  Built with
-                                </VuiTextColor>{" "}
-                                <VuiLinkInternal
-                                  href="https://vectara.com"
-                                  target="_blank"
-                                >
-                                  Vectara
-                                </VuiLinkInternal>
-                              </strong>
-                            </p>
-                          </VuiText>
-                        </VuiFlexItem>
-
-                        <VuiFlexItem>
-                          <VuiText>
-                            <p>
-                              <VuiTextColor color="subdued">
-                                Ctrl+K
-                              </VuiTextColor>
-                            </p>
-                          </VuiText>
-                        </VuiFlexItem>
-                      </VuiFlexContainer>
-
-                      <VuiSpacer size="xs" />
-                    </div>
+                    {children}
                   </div>
                 </div>
               </FocusOn>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   ChangeEvent,
   FC,
   useCallback,
@@ -18,6 +18,7 @@ import { SearchModal } from "./SearchModal";
 import { useSearchHistory } from "./useSearchHistory";
 import "./_index.scss";
 import { BrowserRouter } from "react-router-dom";
+import { SearchInput } from "SearchInput";
 
 const getQueryParam = (urlParams: URLSearchParams, key: string) => {
   const value = urlParams.get(key);
@@ -41,17 +42,21 @@ interface Props {
   // The number of previous searches to cache.
   // Default is 0.
   historySize?: number;
+
+  // The search input placeholder.
+  placeholder?: string;
 }
 
 /**
  * A client-side search component that queries a specific corpus with a user-provided string.
  */
-export const Search: FC<Props> = ({
+export const ReactSearch: FC<Props> = ({
   customerId,
   apiKey,
   corpusId,
   apiUrl,
   historySize = 10,
+  placeholder = "Search",
 }) => {
   // Compute a unique ID for this search component.
   // This creates a namespace, and ensures that stored search results
@@ -59,7 +64,7 @@ export const Search: FC<Props> = ({
   // NOTE: This is an implementation for what's historically been found to be
   // an issue with persistent search history: overlap between the histories
   // of different search boxes.
-  const searchId = React.useMemo(
+  const searchId = useMemo(
     () => getUuid(`${customerId}-${corpusId}-${apiKey}`),
     [customerId, corpusId, apiKey]
   );
@@ -255,7 +260,7 @@ export const Search: FC<Props> = ({
 
                     <VuiFlexItem>
                       <VuiText>
-                        <div>Search</div>
+                        <div>{placeholder}</div>
                       </VuiText>
                     </VuiFlexItem>
                   </VuiFlexContainer>
@@ -266,15 +271,19 @@ export const Search: FC<Props> = ({
             </button>
           </div>
 
-          <SearchModal
-            isLoading={isLoading}
-            searchValue={searchValue}
-            onChange={onChange}
-            onKeyDown={onKeyDown}
-            isOpen={isOpen}
-            resultsList={resultsList}
-            onClose={closeModalAndResetResults}
-          />
+          <SearchModal isOpen={isOpen} onClose={closeModalAndResetResults}>
+            <SearchInput
+              isLoading={isLoading}
+              value={searchValue}
+              onChange={onChange}
+              onKeyDown={onKeyDown}
+              placeholder={placeholder}
+            />
+
+            {resultsList && (
+              <div className="searchModalResults">{resultsList}</div>
+            )}
+          </SearchModal>
         </div>
       </BrowserRouter>
     </>

--- a/src/searchModal.scss
+++ b/src/searchModal.scss
@@ -33,12 +33,6 @@ $modalPadding: 6vh;
     border-top: 1px solid $borderColor;
     overflow-y: auto;
   }
-
-  .searchModalFooter {
-    border-top: 1px solid $borderColor;
-    padding: 0 $sizeM;
-    background-color: $colorLightShade;
-  }
 }
 
 @media only screen and (max-width: 740px) {


### PR DESCRIPTION
## CONTEXT
We need to add a param to accept custom input placeholder defined by the user.

## CHANGES
- added a "placeholder" param to search
- made `SearchInput` and resultsList nodes children of `SearchModal` to avoid prop drilling, as the number of props being drilled down was getting lengthy
- removed search modal footer and corresponding CSS

## SCREENSHOTS

### TOGGLE
#### BEFORE
<img width="666" alt="Screenshot 2024-01-09 at 3 02 06 PM" src="https://github.com/vectara/react-search/assets/1464245/0dedd61b-960a-495b-b1be-75a363af61d3">

#### AFTER
<img width="693" alt="Screenshot 2024-01-09 at 3 01 49 PM" src="https://github.com/vectara/react-search/assets/1464245/b74e83de-1f2d-4e84-be1e-08d154a1ff22">

_Ignore the blue outline, I accidentally focused on the input before taking the screenshot :)_

### SEARCH MODAL (NO SEARCH)
#### BEFORE
<img width="765" alt="Screenshot 2024-01-09 at 3 03 39 PM" src="https://github.com/vectara/react-search/assets/1464245/385d9235-4f93-4093-a35c-60804a844a0e">

#### AFTER
<img width="763" alt="Screenshot 2024-01-09 at 3 01 52 PM" src="https://github.com/vectara/react-search/assets/1464245/64286e3f-6410-4b06-9dab-ea442816cf74">


### SEARCH MODAL (W/ RESULTS)
#### BEFORE
<img width="752" alt="Screenshot 2024-01-09 at 3 03 44 PM" src="https://github.com/vectara/react-search/assets/1464245/c0004584-b001-4c89-97ce-3aefc0fbee5e">

#### AFTER
<img width="746" alt="Screenshot 2024-01-09 at 3 01 24 PM" src="https://github.com/vectara/react-search/assets/1464245/e3952396-93c2-429b-828a-35ec4bca48bf">



