### PR TITLE
fix: prevent search button from reloading page

### DIFF
--- a/src/SearchInput.tsx
+++ b/src/SearchInput.tsx
@@ -26,31 +26,17 @@ export const SearchInput = ({
   ...rest
 }: Props) => {
   return (
-    <form onSubmit={onSubmit}>
-      <div className="searchInput">
-        <input
-          className="searchInput__input"
-          type="text"
-          autoComplete="off"
-          autoCapitalize="off"
-          spellCheck="false"
-          autoFocus={autoFocus}
-          placeholder={placeholder}
-          value={value}
-          onChange={onChange}
-          {...rest}
-        />
-
-        {isLoading ? (
-          <div className="searchInput__submitButton">
-            <VuiSpinner size="xs" />
-          </div>
-        ) : (
-          <button className="searchInput__submitButton" onClick={onSubmit}>
-            <BiSearch size="20px" />
-          </button>
-        )}
-      </div>
-    </form>
+    <input
+      className="searchInput__input"
+      type="text"
+      autoComplete="off"
+      autoCapitalize="off"
+      spellCheck="false"
+      autoFocus={autoFocus}
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+      {...rest}
+    />
   );
 };

--- a/src/SearchInput.tsx
+++ b/src/SearchInput.tsx
@@ -27,7 +27,7 @@ export const SearchInput = ({
 }: Props) => {
   return (
     <input
-      className="searchInput__input"
+      className="searchInput"
       type="text"
       autoComplete="off"
       autoCapitalize="off"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -288,13 +288,13 @@ export const ReactSearch: FC<Props> = ({
                   placeholder={placeholder}
                 />
                 {isLoading ? (
-                  <div className="searchInput__submitButtonWrapper">
+                  <div className="submitButtonWrapper">
                     <VuiSpinner size="xs" />
                   </div>
                 ) : (
-                  <div className="searchInput__submitButtonWrapper">
+                  <div className="submitButtonWrapper">
                     <button
-                      className="searchInput__submitButton"
+                      className="submitButton"
                       onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                         e.preventDefault();
                         sendSearchQuery(searchValue);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,13 @@ import {
 } from "react";
 import { BiSearch } from "react-icons/bi";
 import getUuid from "uuid-by-string";
-import { VuiFlexContainer, VuiFlexItem, VuiIcon, VuiText } from "./vui";
+import {
+  VuiFlexContainer,
+  VuiFlexItem,
+  VuiIcon,
+  VuiSpinner,
+  VuiText,
+} from "./vui";
 import { DeserializedSearchResult } from "./types";
 import { useSearch } from "./useSearch";
 import { SearchResult } from "./SearchResult";
@@ -272,13 +278,34 @@ export const ReactSearch: FC<Props> = ({
           </div>
 
           <SearchModal isOpen={isOpen} onClose={closeModalAndResetResults}>
-            <SearchInput
-              isLoading={isLoading}
-              value={searchValue}
-              onChange={onChange}
-              onKeyDown={onKeyDown}
-              placeholder={placeholder}
-            />
+            <form>
+              <div className="searchForm">
+                <SearchInput
+                  isLoading={isLoading}
+                  value={searchValue}
+                  onChange={onChange}
+                  onKeyDown={onKeyDown}
+                  placeholder={placeholder}
+                />
+                {isLoading ? (
+                  <div className="searchInput__submitButtonWrapper">
+                    <VuiSpinner size="xs" />
+                  </div>
+                ) : (
+                  <div className="searchInput__submitButtonWrapper">
+                    <button
+                      className="searchInput__submitButton"
+                      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                        e.preventDefault();
+                        sendSearchQuery(searchValue);
+                      }}
+                    >
+                      <BiSearch size="20px" />
+                    </button>
+                  </div>
+                )}
+              </div>
+            </form>
 
             {resultsList && (
               <div className="searchModalResults">{resultsList}</div>

--- a/src/searchInput.scss
+++ b/src/searchInput.scss
@@ -4,7 +4,7 @@
   align-items: center;
 }
 
-.searchInput__input {
+.searchInput {
   flex-grow: 1;
   padding: $sizeL;
   background-color: $colorEmptyShade;
@@ -18,11 +18,11 @@
   color: $colorText;
 }
 
-.searchInput__submitButtonWrapper {
+.submitButtonWrapper {
   padding-right: $sizeM;
 }
 
-.searchInput__submitButton {
+.submitButton {
   line-height: 0; // TODO: Should this be applied to all buttons?
   color: $colorDarkShade;
   transition: all $transitionSpeed;

--- a/src/searchInput.scss
+++ b/src/searchInput.scss
@@ -1,4 +1,4 @@
-.searchInput {
+.searchForm {
   position: relative;
   display: flex;
   align-items: center;
@@ -18,9 +18,11 @@
   color: $colorText;
 }
 
+.searchInput__submitButtonWrapper {
+  padding-right: $sizeM;
+}
+
 .searchInput__submitButton {
-  position: absolute;
-  right: $sizeM;
   line-height: 0; // TODO: Should this be applied to all buttons?
   color: $colorDarkShade;
   transition: all $transitionSpeed;


### PR DESCRIPTION
## CONTEXT
When clicking the search button in the search input, the form gets submitted and the page reloads. This should not happen, and the button should fire off a search request instead.

The main goal is to simply execute a search request when clicking the button (or tabbing to it and hitting enter).

## CHANGES
- Extract button out to be a sibling of `SearchInput`: Previously, `SearchInput` was actually returning a form element that packaged together both the actual input and button elements. By extracting the form element and button out of this component, we: 
  - allow `SearchInput` to be implemented with a single responsibility of wrapping an input element, and nothing more
  - allow the button to be a sibling of `SearchInput`, thereby avoiding prop drilling
  - eliminate the need for a separate `onSubmit` prop, since we can now directly leverage `sendSearchRequest`, with the button being moved one level up.

_A simplified visual showing the difference in component structure._
<img width="640" alt="Screenshot 2024-01-10 at 5 01 32 PM" src="https://github.com/vectara/react-search/assets/1464245/58abedc3-0c51-4df2-94f3-a72d9c2b77ae">


## SCREENSHOTS

### BEFORE (via click)
<img src="https://github.com/vectara/react-search/assets/1464245/8890e0a8-e9b0-4388-9e8e-33af604e2ee4" width="400">

### AFTER (via click)
<img src="https://github.com/vectara/react-search/assets/1464245/cb3383a7-68c2-4424-9b65-1a36f268eec1" width="400">

### BEFORE (via tab + enter key)
<img src="https://github.com/vectara/react-search/assets/1464245/6a8d01d1-e8e7-4892-9f95-b8a0f20d43d1" width="400">

### AFTER (via tab + enter key)
<img src="https://github.com/vectara/react-search/assets/1464245/1ddce122-9819-49d9-bb12-2f111eca3760" width="400">

### AFTER (mobile)
<img src="https://github.com/vectara/react-search/assets/1464245/74996857-d891-4fff-b07a-f92fe64c86d2" width="400">

