### PR TITLE
chore: rename package to react-search and adjust version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@vectara/search",
-  "version": "0.1.0",
+  "name": "@vectara/react-search",
+  "version": "0.0.1",
   "description": "A Vectara-powered Search component",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
## CONTEXT

We need to rename the package to reflect the intended framework, and mark it as a beta version.

## CHANGES
- Change package name to @vectara/react-search
- Change package version to 0.0.1