### PR TITLE
chore: Remove react-router-dom dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/react-search",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/react-search",
-      "version": "0.0.2",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/react": "^18.2.45",
@@ -28,14 +28,12 @@
         "live-server": "^1.2.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.21.0",
         "rimraf": "^5.0.5",
         "typescript": "^5.3.3"
       },
       "peerDependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-router-dom": "^6.21.0"
+        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -426,15 +424,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.0.tgz",
-      "integrity": "sha512-WOHih+ClN7N8oHk9N4JUiMxQJmRVaOxcg8w7F/oHUXzJt920ekASLI/7cYX8XkntDWRhLZtsk6LbGrkgOAvi5A==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@types/lodash": {
@@ -2970,38 +2959,6 @@
         }
       }
     },
-    "node_modules/react-router": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.21.0.tgz",
-      "integrity": "sha512-hGZ0HXbwz3zw52pLZV3j3+ec+m/PQ9cTpBvqjFQmy2XVUWGn5MD+31oXHb6dVTxYzmAeaiUBYjkoNz66n3RGCg==",
-      "dev": true,
-      "dependencies": {
-        "@remix-run/router": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.21.0.tgz",
-      "integrity": "sha512-1dUdVj3cwc1npzJaf23gulB562ESNvxf7E4x8upNJycqyUm5BRRZ6dd3LrlzhtLaMrwOCO8R0zoiYxdaJx4LlQ==",
-      "dev": true,
-      "dependencies": {
-        "@remix-run/router": "1.14.0",
-        "react-router": "6.21.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
     "node_modules/react-style-singleton": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
@@ -4310,12 +4267,6 @@
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
       "optional": true
-    },
-    "@remix-run/router": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.0.tgz",
-      "integrity": "sha512-WOHih+ClN7N8oHk9N4JUiMxQJmRVaOxcg8w7F/oHUXzJt920ekASLI/7cYX8XkntDWRhLZtsk6LbGrkgOAvi5A==",
-      "dev": true
     },
     "@types/lodash": {
       "version": "4.14.202",
@@ -6179,25 +6130,6 @@
       "requires": {
         "react-style-singleton": "^2.2.1",
         "tslib": "^2.0.0"
-      }
-    },
-    "react-router": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.21.0.tgz",
-      "integrity": "sha512-hGZ0HXbwz3zw52pLZV3j3+ec+m/PQ9cTpBvqjFQmy2XVUWGn5MD+31oXHb6dVTxYzmAeaiUBYjkoNz66n3RGCg==",
-      "dev": true,
-      "requires": {
-        "@remix-run/router": "1.14.0"
-      }
-    },
-    "react-router-dom": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.21.0.tgz",
-      "integrity": "sha512-1dUdVj3cwc1npzJaf23gulB562ESNvxf7E4x8upNJycqyUm5BRRZ6dd3LrlzhtLaMrwOCO8R0zoiYxdaJx4LlQ==",
-      "dev": true,
-      "requires": {
-        "@remix-run/router": "1.14.0",
-        "react-router": "6.21.0"
       }
     },
     "react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -33,13 +33,11 @@
     "live-server": "^1.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.21.0",
     "rimraf": "^5.0.5",
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.21.0"
+    "react-dom": "^18.2.0"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useEffect,
   useMemo,
+  ReactNode,
 } from "react";
 import { BiSearch } from "react-icons/bi";
 import getUuid from "uuid-by-string";
@@ -23,7 +24,6 @@ import { SearchResult } from "./SearchResult";
 import { SearchModal } from "./SearchModal";
 import { useSearchHistory } from "./useSearchHistory";
 import "./_index.scss";
-import { BrowserRouter } from "react-router-dom";
 import { SearchInput } from "SearchInput";
 
 const getQueryParam = (urlParams: URLSearchParams, key: string) => {
@@ -246,73 +246,70 @@ export const ReactSearch: FC<Props> = ({
 
   return (
     <>
-      <BrowserRouter>
-        <div className="styleWrapper">
-          <div ref={buttonRef}>
-            <button className="searchButton" onClick={() => setIsOpen(true)}>
-              <VuiFlexContainer
-                alignItems="center"
-                spacing="none"
-                justifyContent="spaceBetween"
-                className="searchButton__inner"
-              >
-                <VuiFlexItem>
-                  <VuiFlexContainer alignItems="center" spacing="xs">
-                    <VuiFlexItem>
-                      <VuiIcon>
-                        <BiSearch />
-                      </VuiIcon>
-                    </VuiFlexItem>
+      <div className="styleWrapper">
+        <div ref={buttonRef}>
+          <button className="searchButton" onClick={() => setIsOpen(true)}>
+            <VuiFlexContainer
+              alignItems="center"
+              spacing="none"
+              justifyContent="spaceBetween"
+              className="searchButton__inner"
+            >
+              <VuiFlexItem>
+                <VuiFlexContainer alignItems="center" spacing="xs">
+                  <VuiFlexItem>
+                    <VuiIcon>
+                      <BiSearch />
+                    </VuiIcon>
+                  </VuiFlexItem>
 
-                    <VuiFlexItem>
-                      <VuiText>
-                        <div>Search</div>
-                      </VuiText>
-                    </VuiFlexItem>
-                  </VuiFlexContainer>
-                </VuiFlexItem>
+                  <VuiFlexItem>
+                    <VuiText>
+                      <div>Search</div>
+                    </VuiText>
+                  </VuiFlexItem>
+                </VuiFlexContainer>
+              </VuiFlexItem>
 
-                <div className="searchButtonShortcut">Ctrl + K</div>
-              </VuiFlexContainer>
-            </button>
-          </div>
-
-          <SearchModal isOpen={isOpen} onClose={closeModalAndResetResults}>
-            <form>
-              <div className="searchForm">
-                <SearchInput
-                  isLoading={isLoading}
-                  value={searchValue}
-                  onChange={onChange}
-                  onKeyDown={onKeyDown}
-                  placeholder={placeholder}
-                />
-                {isLoading ? (
-                  <div className="submitButtonWrapper">
-                    <VuiSpinner size="xs" />
-                  </div>
-                ) : (
-                  <div className="submitButtonWrapper">
-                    <button
-                      className="submitButton"
-                      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                        e.preventDefault();
-                        sendSearchQuery(searchValue);
-                      }}
-                    >
-                      <BiSearch size="20px" />
-                    </button>
-                  </div>
-                )}
-              </div>
-            </form>
-
-            {resultsList && (
-              <div className="searchModalResults">{resultsList}</div>
-            )}
-          </SearchModal>
+              <div className="searchButtonShortcut">Ctrl + K</div>
+            </VuiFlexContainer>
+          </button>
         </div>
-      </BrowserRouter>
+        <SearchModal isOpen={isOpen} onClose={closeModalAndResetResults}>
+          <form>
+            <div className="searchForm">
+              <SearchInput
+                isLoading={isLoading}
+                value={searchValue}
+                onChange={onChange}
+                onKeyDown={onKeyDown}
+                placeholder={placeholder}
+              />
+              {isLoading ? (
+                <div className="submitButtonWrapper">
+                  <VuiSpinner size="xs" />
+                </div>
+              ) : (
+                <div className="submitButtonWrapper">
+                  <button
+                    className="submitButton"
+                    onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                      e.preventDefault();
+                      sendSearchQuery(searchValue);
+                    }}
+                  >
+                    <BiSearch size="20px" />
+                  </button>
+                </div>
+              )}
+            </div>
+          </form>
+
+          {resultsList && (
+            <div className="searchModalResults">{resultsList}</div>
+          )}
+        </SearchModal>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## CONTEXT

Since the SearchResult component no longer leverages the `Link` component from `react-router-dom`, we can remove it now. This also fixes a problem where, if the consuming app ends up wrapping `ReactSearch` in `BrowserRouter` component, the whole app crashes. This is because there can only be one router instance at a time.

## CHANGES
- Remove BrowserRouter usage
- Remove react-router-dom dependency.