### PR TITLE
feature: add support for openResultsInNewTab prop

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,5 @@ global.d.ts
 package-lock.json
 README.md
 tsconfig.json
+setupTests.ts
+jest.config.js

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Configure the placeholder text in the search modal's input.
 
 Defaults to `false`. Set this option if you want to persist a search query to a URL parameter. This will enable users to share or bookmark the URL. Loading the URL will automatically open the search modal and search for the query that's stored in the URL.
 
+#### `openResultsInNewTab` (optional)
+
+Defaults to `false`. Set this option if you want a search result to open in a new tab.
+
 ### Set up your search data
 
 React-Search pulls data from your Vectara corpus. To set this up:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,7 @@
 {
   "name": "@vectara/react-search",
-<<<<<<< HEAD
-  "version": "0.0.1",
-  "lockfileVersion": 3,
-=======
   "version": "0.0.4",
-  "lockfileVersion": 2,
->>>>>>> 8711b05 (address comments)
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,17 @@
 {
   "name": "@vectara/react-search",
+<<<<<<< HEAD
   "version": "0.0.1",
   "lockfileVersion": 3,
+=======
+  "version": "0.0.4",
+  "lockfileVersion": 2,
+>>>>>>> 8711b05 (address comments)
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/react-search",
-      "version": "0.0.1",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "@types/react": "^18.2.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectara/react-search",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "description": "A Vectara-powered Search component",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/SearchResult.test.tsx
+++ b/src/SearchResult.test.tsx
@@ -53,16 +53,16 @@ describe("SearchResult", () => {
     });
 
     it("should render an anchor tag that opens in a new tab if configured", () => {
-      render(<SearchResult searchResult={MOCK_SEARCH_RESULT} isSelected={false} shouldOpenInNewTab={true} />);
-      const anchor = screen.getByTestId("vectara-react-search-result-link");
+      render(<SearchResult searchResult={MOCK_SEARCH_RESULT} isSelected={false} opensInNewTab={true} />);
+      const anchor = screen.getByTestId("vrsResultLink");
 
       expect(anchor).toHaveAttribute("href", MOCK_SEARCH_RESULT.url);
       expect(anchor).toHaveAttribute("target", "_blank");
     });
 
     it("should have the right class name if selected or not selected", () => {
-      render(<SearchResult searchResult={MOCK_SEARCH_RESULT} isSelected={true} shouldOpenInNewTab={true} />);
-      let anchor = screen.getByTestId("vectara-react-search-result-link");
+      render(<SearchResult searchResult={MOCK_SEARCH_RESULT} isSelected={true} opensInNewTab={true} />);
+      let anchor = screen.getByTestId("vrsResultLink");
 
       expect(anchor).toHaveClass("isSelected");
     });
@@ -75,11 +75,11 @@ describe("SearchResult", () => {
     };
     it("should render a div if no URL was provided", () => {
       render(<SearchResult searchResult={searchResultNoUrl} isSelected={false} />);
-      const anchor = screen.queryByTestId("vectara-react-search-result-link");
-      const div = screen.getByTestId("vectara-react-search-result-div");
+      const anchor = screen.queryByTestId("vrsResultLink");
+      const wrapper = screen.getByTestId("vrsResultWrapper");
 
       expect(anchor).not.toBeInTheDocument();
-      expect(div).toBeInTheDocument();
+      expect(wrapper).toBeInTheDocument();
     });
   });
 });

--- a/src/SearchResult.test.tsx
+++ b/src/SearchResult.test.tsx
@@ -8,30 +8,26 @@ const MOCK_SEARCH_RESULT: DeserializedSearchResult = {
   snippet: {
     pre: "mock-pre-snippet",
     text: "mock-text-snippet",
-    post: "mock-post-snippet",
+    post: "mock-post-snippet"
   },
   source: "mock-source",
   url: "mock-url",
   title: "mock-title",
   metadata: {
-    "mock-metadata-key-1": "mock-metadata-value-1",
-  },
+    "mock-metadata-key-1": "mock-metadata-value-1"
+  }
 };
 
 describe("SearchResult", () => {
   it("should render text content", () => {
-    render(
-      <SearchResult searchResult={MOCK_SEARCH_RESULT} isSelected={false} />
-    );
+    render(<SearchResult searchResult={MOCK_SEARCH_RESULT} isSelected={false} />);
     const text = screen.getByText(MOCK_SEARCH_RESULT.snippet.text);
 
     expect(text).toBeInTheDocument();
   });
 
   it("should render the title if provided", () => {
-    render(
-      <SearchResult searchResult={MOCK_SEARCH_RESULT} isSelected={false} />
-    );
+    render(<SearchResult searchResult={MOCK_SEARCH_RESULT} isSelected={false} />);
     const title = screen.getByText(MOCK_SEARCH_RESULT.title!);
 
     expect(title).toBeInTheDocument();
@@ -39,9 +35,7 @@ describe("SearchResult", () => {
 
   it("should not render the title if not provided", () => {
     const searchResultNoTitle = { ...MOCK_SEARCH_RESULT, title: undefined };
-    const { container } = render(
-      <SearchResult searchResult={searchResultNoTitle} isSelected={false} />
-    );
+    const { container } = render(<SearchResult searchResult={searchResultNoTitle} isSelected={false} />);
     const pElements = container.querySelectorAll("p");
 
     // There should only be one <p> tag - the one containing the text.
@@ -51,44 +45,24 @@ describe("SearchResult", () => {
 
   describe("with URL", () => {
     it("should render an anchor tag that opens in the same window by default", () => {
-      render(
-        <SearchResult searchResult={MOCK_SEARCH_RESULT} isSelected={false} />
-      );
-      const anchor = screen
-        .getByText(MOCK_SEARCH_RESULT.snippet.text)
-        .closest("a");
+      render(<SearchResult searchResult={MOCK_SEARCH_RESULT} isSelected={false} />);
+      const anchor = screen.getByText(MOCK_SEARCH_RESULT.snippet.text).closest("a");
 
       expect(anchor).toHaveAttribute("href", MOCK_SEARCH_RESULT.url);
       expect(anchor).toHaveAttribute("target", "_self");
     });
 
     it("should render an anchor tag that opens in a new tab if configured", () => {
-      render(
-        <SearchResult
-          searchResult={MOCK_SEARCH_RESULT}
-          isSelected={false}
-          shouldOpenInNewWindow={true}
-        />
-      );
-      const anchor = screen
-        .getByText(MOCK_SEARCH_RESULT.snippet.text)
-        .closest("a");
+      render(<SearchResult searchResult={MOCK_SEARCH_RESULT} isSelected={false} shouldOpenInNewTab={true} />);
+      const anchor = screen.getByTestId("vectara-react-search-result-link");
 
       expect(anchor).toHaveAttribute("href", MOCK_SEARCH_RESULT.url);
       expect(anchor).toHaveAttribute("target", "_blank");
     });
 
     it("should have the right class name if selected or not selected", () => {
-      render(
-        <SearchResult
-          searchResult={MOCK_SEARCH_RESULT}
-          isSelected={true}
-          shouldOpenInNewWindow={true}
-        />
-      );
-      let anchor = screen
-        .getByText(MOCK_SEARCH_RESULT.snippet.text)
-        .closest("a");
+      render(<SearchResult searchResult={MOCK_SEARCH_RESULT} isSelected={true} shouldOpenInNewTab={true} />);
+      let anchor = screen.getByTestId("vectara-react-search-result-link");
 
       expect(anchor).toHaveClass("isSelected");
     });
@@ -97,20 +71,15 @@ describe("SearchResult", () => {
   describe("without URL", () => {
     const searchResultNoUrl = {
       ...MOCK_SEARCH_RESULT,
-      url: undefined,
+      url: undefined
     };
     it("should render a div if no URL was provided", () => {
-      render(
-        <SearchResult searchResult={searchResultNoUrl} isSelected={false} />
-      );
-      const divWithTextContent = screen.getByText(
-        MOCK_SEARCH_RESULT.snippet.text
-      );
-      const anchor = divWithTextContent.closest("a");
-      const wrappingDiv = divWithTextContent.closest("div");
+      render(<SearchResult searchResult={searchResultNoUrl} isSelected={false} />);
+      const anchor = screen.queryByTestId("vectara-react-search-result-link");
+      const div = screen.getByTestId("vectara-react-search-result-div");
 
       expect(anchor).not.toBeInTheDocument();
-      expect(wrappingDiv).toBeInTheDocument();
+      expect(div).toBeInTheDocument();
     });
   });
 });

--- a/src/SearchResult.tsx
+++ b/src/SearchResult.tsx
@@ -3,10 +3,10 @@ import { DeserializedSearchResult } from "./types";
 type Props = {
   searchResult: DeserializedSearchResult;
   isSelected?: boolean;
-  shouldOpenInNewWindow?: boolean;
+  shouldOpenInNewTab?: boolean;
 };
 
-export const SearchResult = ({ searchResult, isSelected = false, shouldOpenInNewWindow = false }: Props) => {
+export const SearchResult = ({ searchResult, isSelected = false, shouldOpenInNewTab = false }: Props) => {
   const {
     title,
     url,
@@ -23,14 +23,19 @@ export const SearchResult = ({ searchResult, isSelected = false, shouldOpenInNew
   if (url) {
     return (
       <a
+        data-testid="vectara-react-search-result-link"
         className={`vrsSearchResult vrsSearchResult-isLink ${isSelected ? "isSelected" : ""}`}
         href={url}
-        target={shouldOpenInNewWindow ? "_blank" : "_self"}
+        target={shouldOpenInNewTab ? "_blank" : "_self"}
       >
         {content}
       </a>
     );
   }
 
-  return <div className="vrsSearchResult">{content}</div>;
+  return (
+    <div data-testid="vectara-react-search-result-div" className="vrsSearchResult">
+      {content}
+    </div>
+  );
 };

--- a/src/SearchResult.tsx
+++ b/src/SearchResult.tsx
@@ -3,10 +3,10 @@ import { DeserializedSearchResult } from "./types";
 type Props = {
   searchResult: DeserializedSearchResult;
   isSelected?: boolean;
-  shouldOpenInNewTab?: boolean;
+  opensInNewTab?: boolean;
 };
 
-export const SearchResult = ({ searchResult, isSelected = false, shouldOpenInNewTab = false }: Props) => {
+export const SearchResult = ({ searchResult, isSelected = false, opensInNewTab = false }: Props) => {
   const {
     title,
     url,
@@ -23,10 +23,10 @@ export const SearchResult = ({ searchResult, isSelected = false, shouldOpenInNew
   if (url) {
     return (
       <a
-        data-testid="vectara-react-search-result-link"
+        data-testid="vrsResultLink"
         className={`vrsSearchResult vrsSearchResult-isLink ${isSelected ? "isSelected" : ""}`}
         href={url}
-        target={shouldOpenInNewTab ? "_blank" : "_self"}
+        target={opensInNewTab ? "_blank" : "_self"}
       >
         {content}
       </a>
@@ -34,7 +34,7 @@ export const SearchResult = ({ searchResult, isSelected = false, shouldOpenInNew
   }
 
   return (
-    <div data-testid="vectara-react-search-result-div" className="vrsSearchResult">
+    <div data-testid="vrsResultWrapper" className="vrsSearchResult">
       {content}
     </div>
   );

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -75,7 +75,7 @@ describe("ReactSearch", () => {
       });
 
       expect(searchResultSpy).toHaveBeenCalledWith(
-        { isSelected: false, searchResult: MOCK_SEARCH_RESULT, shouldOpenInNewTab: false },
+        { isSelected: false, searchResult: MOCK_SEARCH_RESULT, opensInNewTab: false },
         {}
       );
     });
@@ -91,7 +91,7 @@ describe("ReactSearch", () => {
       });
 
       expect(searchResultSpy).toHaveBeenCalledWith(
-        { isSelected: false, searchResult: MOCK_SEARCH_RESULT, shouldOpenInNewTab: false },
+        { isSelected: false, searchResult: MOCK_SEARCH_RESULT, opensInNewTab: false },
         {}
       );
     });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,7 +25,7 @@ const getQueryParam = (urlParams: URLSearchParams, key: string) => {
   return undefined;
 };
 
-interface Props {
+export interface Props {
   // Vectara customer ID
   customerId: string;
 
@@ -47,6 +47,9 @@ interface Props {
 
   // Whether to enable deeplinking to a particular search.
   isDeeplinkable?: boolean;
+
+  // Whether to open selected results in a new browser tab.
+  openResultsInNewTab?: boolean;
 }
 
 /**
@@ -59,7 +62,8 @@ export const ReactSearch: FC<Props> = ({
   apiUrl,
   historySize = 10,
   placeholder = "Search",
-  isDeeplinkable = false
+  isDeeplinkable = false,
+  openResultsInNewTab = false
 }) => {
   // Compute a unique ID for this search component.
   // This creates a namespace, and ensures that stored search results
@@ -139,7 +143,7 @@ export const ReactSearch: FC<Props> = ({
         evt.preventDefault();
 
         if (selectedResultIndex !== null) {
-          window.open(searchResults[selectedResultIndex].url, "_self");
+          window.open(searchResults[selectedResultIndex].url, openResultsInNewTab ? "_blank" : "_self");
         } else {
           sendSearchQuery(searchValue);
         }
@@ -193,7 +197,11 @@ export const ReactSearch: FC<Props> = ({
 
           return (
             <div ref={selectedResultIndex === index ? selectedResultRef : undefined} key={`${pre}${text}${post}`}>
-              <SearchResult searchResult={searchResult} isSelected={selectedResultIndex === index} />
+              <SearchResult
+                searchResult={searchResult}
+                isSelected={selectedResultIndex === index}
+                shouldOpenInNewTab={openResultsInNewTab}
+              />
             </div>
           );
         });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -200,7 +200,7 @@ export const ReactSearch: FC<Props> = ({
               <SearchResult
                 searchResult={searchResult}
                 isSelected={selectedResultIndex === index}
-                shouldOpenInNewTab={openResultsInNewTab}
+                opensInNewTab={openResultsInNewTab}
               />
             </div>
           );


### PR DESCRIPTION
## CONTEXT

Search results have always had the optional ability to open links in a new tab. We need to expose this to the top-level `ReactSearch` component as a prop.

## CHANGES
- add support for `openResultsInNewTab` boolean prop
- add unit tests
- update SearchResult unit tests to use test ids
- update README