### PR TITLE
chore: prefix css selectors

### DIFF
--- a/src/SearchInput.tsx
+++ b/src/SearchInput.tsx
@@ -1,8 +1,4 @@
-import {
-  ChangeEventHandler,
-  FormEventHandler,
-  KeyboardEventHandler,
-} from "react";
+import { ChangeEventHandler, FormEventHandler, KeyboardEventHandler } from "react";
 
 type Props = {
   value?: string;
@@ -13,17 +9,10 @@ type Props = {
   onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
 };
 
-export const SearchInput = ({
-  value,
-  onChange,
-  placeholder,
-  autoFocus,
-  onSubmit,
-  ...rest
-}: Props) => {
+export const SearchInput = ({ value, onChange, placeholder, autoFocus, onSubmit, ...rest }: Props) => {
   return (
     <input
-      className="searchInput"
+      className="vrsSearchInput"
       type="text"
       autoComplete="off"
       autoCapitalize="off"

--- a/src/SearchModal.tsx
+++ b/src/SearchModal.tsx
@@ -8,51 +8,49 @@ type Props = {
   children?: ReactNode[];
 };
 
-export const SearchModal = forwardRef(
-  ({ onClose, isOpen, children }: Props, ref: ForwardedRef<HTMLDivElement>) => {
-    const returnFocusElRef = useRef<HTMLElement | null>(null);
+export const SearchModal = forwardRef(({ onClose, isOpen, children }: Props, ref: ForwardedRef<HTMLDivElement>) => {
+  const returnFocusElRef = useRef<HTMLElement | null>(null);
 
-    // Return focus on unmount.
-    useEffect(() => {
-      if (isOpen) {
-        returnFocusElRef.current = document.activeElement as HTMLElement;
-      } else {
-        returnFocusElRef.current?.focus();
-        returnFocusElRef.current = null;
-      }
-    }, [isOpen]);
+  // Return focus on unmount.
+  useEffect(() => {
+    if (isOpen) {
+      returnFocusElRef.current = document.activeElement as HTMLElement;
+    } else {
+      returnFocusElRef.current?.focus();
+      returnFocusElRef.current = null;
+    }
+  }, [isOpen]);
 
-    // Allow contents to respond to blur events before unmounting.
-    const onCloseDelayed = () => {
-      window.setTimeout(() => {
-        onClose();
-      }, 0);
-    };
+  // Allow contents to respond to blur events before unmounting.
+  const onCloseDelayed = () => {
+    window.setTimeout(() => {
+      onClose();
+    }, 0);
+  };
 
-    return (
-      <VuiPortal>
-        <div className="styleWrapper">
-          {isOpen && (
-            <VuiScreenBlock>
-              <FocusOn
-                onEscapeKey={onCloseDelayed}
-                onClickOutside={onCloseDelayed}
-                // Enable manual focus return to work.
-                returnFocus={false}
-                // Enable focus on contents when it's open,
-                // but enable manual focus return to work when it's closed.
-                autoFocus={isOpen}
-              >
-                <div className="searchModalContainer">
-                  <div ref={ref} className="searchModal">
-                    {children}
-                  </div>
+  return (
+    <VuiPortal>
+      <div className="styleWrapper">
+        {isOpen && (
+          <VuiScreenBlock>
+            <FocusOn
+              onEscapeKey={onCloseDelayed}
+              onClickOutside={onCloseDelayed}
+              // Enable manual focus return to work.
+              returnFocus={false}
+              // Enable focus on contents when it's open,
+              // but enable manual focus return to work when it's closed.
+              autoFocus={isOpen}
+            >
+              <div className="vrsSearchModalContainer">
+                <div ref={ref} className="vrsSearchModal">
+                  {children}
                 </div>
-              </FocusOn>
-            </VuiScreenBlock>
-          )}
-        </div>
-      </VuiPortal>
-    );
-  }
-);
+              </div>
+            </FocusOn>
+          </VuiScreenBlock>
+        )}
+      </div>
+    </VuiPortal>
+  );
+});

--- a/src/SearchModal.tsx
+++ b/src/SearchModal.tsx
@@ -30,7 +30,7 @@ export const SearchModal = forwardRef(({ onClose, isOpen, children }: Props, ref
 
   return (
     <VuiPortal>
-      <div className="styleWrapper">
+      <div className="vrsStyleWrapper">
         {isOpen && (
           <VuiScreenBlock>
             <FocusOn

--- a/src/SearchResult.tsx
+++ b/src/SearchResult.tsx
@@ -6,30 +6,24 @@ type Props = {
   shouldOpenInNewWindow?: boolean;
 };
 
-export const SearchResult = ({
-  searchResult,
-  isSelected = false,
-  shouldOpenInNewWindow = false,
-}: Props) => {
+export const SearchResult = ({ searchResult, isSelected = false, shouldOpenInNewWindow = false }: Props) => {
   const {
     title,
     url,
-    snippet: { text },
+    snippet: { text }
   } = searchResult;
 
   const content = (
     <>
-      {title && <p className="searchResultTitle">{title}</p>}
-      <p className="searchResultSnippet">{text}</p>
+      {title && <p className="vrsSearchResultTitle">{title}</p>}
+      <p className="vrsSearchResultSnippet">{text}</p>
     </>
   );
 
   if (url) {
     return (
       <a
-        className={`searchResult searchResult-isLink ${
-          isSelected ? "isSelected" : ""
-        }`}
+        className={`vrsSearchResult vrsSearchResult-isLink ${isSelected ? "isSelected" : ""}`}
         href={url}
         target={shouldOpenInNewWindow ? "_blank" : "_self"}
       >
@@ -38,5 +32,5 @@ export const SearchResult = ({
     );
   }
 
-  return <div className="searchResult">{content}</div>;
+  return <div className="vrsSearchResult">{content}</div>;
 };

--- a/src/_index.scss
+++ b/src/_index.scss
@@ -14,7 +14,7 @@ button {
   font-size: inherit;
 }
 
-.styleWrapper {
+.vrsStyleWrapper {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
     "Droid Sans", "Helvetica Neue", sans-serif;
 }

--- a/src/_index.scss
+++ b/src/_index.scss
@@ -15,12 +15,11 @@ button {
 }
 
 .styleWrapper {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
+    "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
-.searchButton {
+.vrsSearchButton {
   display: flex;
   width: 100%;
   box-shadow: rgba(50, 50, 93, 0.25) 0px 0 0 0, rgba(0, 0, 0, 0.16) 0px 1px 4px;
@@ -42,17 +41,16 @@ button {
 
   &:hover {
     border-color: $colorPrimary;
-    box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px,
-      rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
+    box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px, rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
     z-index: 1;
   }
 }
 
-.searchButton__inner {
+.vrsSearchButton__inner {
   flex-grow: 1;
 }
 
-.searchButtonShortcut {
+.vrsSearchButtonShortcut {
   padding: $sizeXs;
   border-radius: $sizeXxxs;
   font-size: $fontSizeStandard;
@@ -60,7 +58,7 @@ button {
   color: $colorPrimary;
 }
 
-.searchModalContainer {
+.vrsSearchModalContainer {
   @import "./vui/_reset";
   @import "./searchInput";
   @import "./searchResult";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -223,7 +223,7 @@ export const ReactSearch: FC<Props> = ({
 
   return (
     <>
-      <div className="styleWrapper">
+      <div className="vrsStyleWrapper">
         <div ref={buttonRef}>
           <button className="vrsSearchButton" onClick={() => setIsOpen(true)}>
             <VuiFlexContainer

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -225,12 +225,12 @@ export const ReactSearch: FC<Props> = ({
     <>
       <div className="styleWrapper">
         <div ref={buttonRef}>
-          <button className="searchButton" onClick={() => setIsOpen(true)}>
+          <button className="vrsSearchButton" onClick={() => setIsOpen(true)}>
             <VuiFlexContainer
               alignItems="center"
               spacing="none"
               justifyContent="spaceBetween"
-              className="searchButton__inner"
+              className="vrsSearchButton__inner"
             >
               <VuiFlexItem>
                 <VuiFlexContainer alignItems="center" spacing="xs">
@@ -248,22 +248,22 @@ export const ReactSearch: FC<Props> = ({
                 </VuiFlexContainer>
               </VuiFlexItem>
 
-              <div className="searchButtonShortcut">Ctrl + K</div>
+              <div className="vrsSearchButtonShortcut">Ctrl + K</div>
             </VuiFlexContainer>
           </button>
         </div>
         <SearchModal isOpen={isOpen} onClose={closeModalAndResetResults}>
           <form>
-            <div className="searchForm">
+            <div className="vrsSearchForm">
               <SearchInput value={searchValue} onChange={onChange} onKeyDown={onKeyDown} placeholder={placeholder} />
               {isLoading ? (
-                <div className="submitButtonWrapper">
+                <div className="vrsSubmitButtonWrapper">
                   <VuiSpinner size="xs" />
                 </div>
               ) : (
-                <div className="submitButtonWrapper">
+                <div className="vrsSubmitButtonWrapper">
                   <button
-                    className="submitButton"
+                    className="vrsSubmitButton"
                     onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                       e.preventDefault();
                       sendSearchQuery(searchValue);
@@ -276,7 +276,7 @@ export const ReactSearch: FC<Props> = ({
             </div>
           </form>
 
-          {resultsList && <div className="searchModalResults">{resultsList}</div>}
+          {resultsList && <div className="vrsSearchModalResults">{resultsList}</div>}
         </SearchModal>
       </div>
     </>

--- a/src/searchInput.scss
+++ b/src/searchInput.scss
@@ -1,10 +1,10 @@
-.searchForm {
+.vrsSearchForm {
   position: relative;
   display: flex;
   align-items: center;
 }
 
-.searchInput {
+.vrsSearchInput {
   flex-grow: 1;
   padding: $sizeL;
   background-color: $colorEmptyShade;
@@ -18,11 +18,11 @@
   color: $colorText;
 }
 
-.submitButtonWrapper {
+.vrsSubmitButtonWrapper {
   padding-right: $sizeM;
 }
 
-.submitButton {
+.vrsSubmitButton {
   line-height: 0; // TODO: Should this be applied to all buttons?
   color: $colorDarkShade;
   transition: all $transitionSpeed;

--- a/src/searchModal.scss
+++ b/src/searchModal.scss
@@ -1,6 +1,6 @@
 $modalPadding: 6vh;
 
-.searchModalContainer {
+.vrsSearchModalContainer {
   position: fixed;
   top: 0;
   left: 0;
@@ -12,7 +12,7 @@ $modalPadding: 6vh;
   animation: modalIn 0.2s cubic-bezier(0, 1, 1, 1);
   pointer-events: none;
 
-  .searchModal {
+  .vrsSearchModal {
     margin-top: $modalPadding;
     background-color: $colorEmptyShade;
     display: flex;
@@ -23,23 +23,22 @@ $modalPadding: 6vh;
     z-index: $modalZIndex;
     pointer-events: all;
     background-color: $colorEmptyShade;
-    box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px,
-      rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
+    box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px, rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
     border-radius: $sizeXs;
     overflow: hidden;
   }
 
-  .searchModalResults {
+  .vrsSearchModalResults {
     border-top: 1px solid $borderColor;
     overflow-y: auto;
   }
 }
 
 @media only screen and (max-width: 740px) {
-  .searchModalContainer {
+  .vrsSearchModalContainer {
     overflow-y: auto;
 
-    .searchModal {
+    .vrsSearchModal {
       margin-top: 0 !important;
       max-width: 100vw !important;
       max-height: none !important;
@@ -47,7 +46,7 @@ $modalPadding: 6vh;
       overflow: initial !important;
     }
 
-    .searchModalResults {
+    .vrsSearchModalResults {
       overflow-y: none !important;
     }
   }

--- a/src/searchResult.scss
+++ b/src/searchResult.scss
@@ -1,4 +1,4 @@
-.searchResult {
+.vrsSearchResult {
   background-color: $colorEmptyShade;
   display: block;
   padding: $sizeS $sizeL $sizeS $sizeL;
@@ -14,7 +14,7 @@
   }
 }
 
-.searchResult-isLink {
+.vrsSearchResult-isLink {
   padding-left: $sizeM;
   border-left: $sizeS solid $colorEmptyShade;
 
@@ -22,17 +22,17 @@
   &.isSelected {
     border-left: $sizeS solid $colorPrimary;
 
-    .searchResultTitle {
+    .vrsSearchResultTitle {
       text-decoration: underline;
     }
   }
 
-  .searchResultTitle {
+  .vrsSearchResultTitle {
     color: $colorPrimary;
   }
 }
 
-.searchResultTitle {
+.vrsSearchResultTitle {
   color: $colorDarkerShade;
   font-size: 14px;
   font-weight: 700;
@@ -40,7 +40,7 @@
   margin-bottom: $sizeXxs;
 }
 
-.searchResultSnippet {
+.vrsSearchResultSnippet {
   color: $colorDarkerShade;
   font-size: 14px;
   line-height: 20px;


### PR DESCRIPTION
## CONTEXT

To help prevent collisions with CSS selectors in a consumer app, we need to prefix our own CSS selectors.

## CHANGES
- prefix CSS selectors with "vrs" (Vectara React Search)