### PR TITLE
chore: add react-icons to dev dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,21 @@ jobs:
       - run: npm install
       - run: npm run build
 
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          cache: "npm"
+      - run: npm install
+      - run: npm run build
+      - run: npm run buildDevScript
+
   run-unit-tests:
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18.x

--- a/buildConfigs.js
+++ b/buildConfigs.js
@@ -1,6 +1,6 @@
 const { sassPlugin } = require("esbuild-sass-plugin");
 const cssPlugin = require("esbuild-css-modules-plugin");
-const { dependencies, peerDependencies } = require("./package.json");
+const { dependencies, devDependencies, peerDependencies } = require("./package.json");
 const entryFile = "src/index.tsx";
 
 const sharedConfig = {
@@ -10,20 +10,20 @@ const sharedConfig = {
   treeShaking: true,
   minify: true,
   sourcemap: true,
-  external: [...Object.keys(dependencies), ...Object.keys(peerDependencies)],
+  external: [...Object.keys(dependencies), ...Object.keys(devDependencies), ...Object.keys(peerDependencies)],
   target: ["esnext", "node12.22.0"],
-  plugins: [cssPlugin(), sassPlugin({ type: "style" })],
+  plugins: [cssPlugin(), sassPlugin({ type: "style" })]
 };
 
 module.exports = {
   esm: {
     ...sharedConfig,
     format: "esm",
-    outfile: "./dist/index.esm.js",
+    outfile: "./dist/index.esm.js"
   },
   cjs: {
     ...sharedConfig,
     format: "cjs",
-    outfile: "./dist/index.cjs.js",
-  },
+    outfile: "./dist/index.cjs.js"
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "markdown-to-jsx": "^7.3.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.0.1",
         "react-router-dom": "^6.8.2",
         "rimraf": "^5.0.5",
         "ts-jest": "^29.1.1",
@@ -7711,6 +7712,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "markdown-to-jsx": "^7.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.0.1",
     "react-router-dom": "^6.8.2",
     "rimraf": "^5.0.5",
     "ts-jest": "^29.1.1",


### PR DESCRIPTION
## CONTEXT

Removing react-icons broke the docs page since it needs react-icons. Adding react-icons to dev-dependencies fixes the issue.

## CHANGES

- add react-icons to dev dependencies
- add build-docs job to validate docs site for every PR