### PR TITLE
chore: add docs page toggles for deeplink and results in new tab props

### DIFF
--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -34,6 +34,8 @@ const Content = () => {
   const [customerId, setCustomerId] = useState<string>("");
   const [apiKey, setApiKey] = useState<string>("");
   const [placeholder, setPlaceholder] = useState<string>(DEFAULT_PLACEHOLDER);
+  const [isDeeplinkable, setIsDeeplinkable] = useState<boolean>(false);
+  const [openResultsInNewTab, setOpenResultsInNewTab] = useState<boolean>(false);
 
   const onUpdateCorpusId = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setCorpusId(e.target.value);
@@ -49,6 +51,14 @@ const Content = () => {
 
   const onUpdatePlaceholder = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setPlaceholder(e.target.value);
+  }, []);
+
+  const onUpdateIsDeeplinkable = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setIsDeeplinkable(e.target.checked);
+  }, []);
+
+  const onUpdateOpenResultsInNewTab = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setOpenResultsInNewTab(e.target.checked);
   }, []);
 
   return (
@@ -77,6 +87,8 @@ const Content = () => {
           customerId={customerId === "" ? DEFAULT_CUSTOMER_ID : customerId}
           apiKey={apiKey === "" ? DEFAULT_API_KEY : apiKey}
           placeholder={placeholder}
+          isDeeplinkable={isDeeplinkable}
+          openResultsInNewTab={openResultsInNewTab}
         />
       </div>
 
@@ -106,7 +118,9 @@ const Content = () => {
 
       <VuiSpacer size="s" />
 
-      <VuiCode language="tsx">{codeSnippet}</VuiCode>
+      <VuiCode language="tsx">
+        {generateCodeSnippet(customerId, corpusId, apiKey, placeholder, isDeeplinkable, openResultsInNewTab)}
+      </VuiCode>
 
       <ConfigurationDrawer
         isOpen={isConfigurationDrawerOpen}
@@ -119,23 +133,61 @@ const Content = () => {
         onUpdateApiKey={onUpdateApiKey}
         placeholder={placeholder}
         onUpdatePlaceholder={onUpdatePlaceholder}
+        isDeeplinkable={isDeeplinkable}
+        onUpdateIsDeeplinkable={onUpdateIsDeeplinkable}
+        openResultsInNewTab={openResultsInNewTab}
+        onUpdateOpenResultsInNewTab={onUpdateOpenResultsInNewTab}
       />
     </div>
   );
 };
 
-const codeSnippet = `import { ReactSearch } from "@vectara/react-search";
+const generateCodeSnippet = (
+  customerId?: string,
+  corpusId?: string,
+  apiKey?: string,
+  placeholder?: string,
+  isDeepLinkable: boolean = false,
+  openResultsInNewTab: boolean = false
+) => {
+  let quotedPlaceholder = placeholder;
 
-export const App = () => (
-  <div>
-    <ReactSearch
-      customerId="<Your Vectara customer ID>"
-      corpusId="<Your Vectara corpus ID>"
-      apiKey="<Your Vectara API key>"
-      placeholder="What would you like to search for?"
-    />
-  </div>
-);`;
+  if (placeholder) {
+    if (placeholder.match('"')) {
+      quotedPlaceholder = `'${placeholder}'`;
+    } else {
+      quotedPlaceholder = `"${placeholder}"`;
+    }
+  }
+
+  const props = [
+    `customerId="${customerId === "" ? "<Your Vectara customer ID>" : customerId}"`,
+    `corpusId="${corpusId === "" ? "<Your Vectara corpus ID>" : corpusId}"`,
+    `apiKey="${apiKey === "" ? "<Your Vectara API key>" : apiKey}"`
+  ];
+
+  if (placeholder) {
+    props.push(`placeholder=${quotedPlaceholder}`);
+  }
+
+  if (isDeepLinkable) {
+    props.push(`isDeeplinkable={${isDeepLinkable}}`);
+  }
+
+  if (openResultsInNewTab) {
+    props.push(`openResultsInNewTab={${openResultsInNewTab}}`);
+  }
+
+  return `import { ReactSearch } from "@vectara/react-search";
+
+  export const App = () => (
+    <div>
+      <ReactSearch
+        ${props.join("\n        ")}
+      />
+    </div>
+  );`;
+};
 
 const App = () => {
   return (

--- a/dev/src/components/ConfigurationDrawer.tsx
+++ b/dev/src/components/ConfigurationDrawer.tsx
@@ -1,4 +1,14 @@
-import { VuiButtonPrimary, VuiDrawer, VuiLink, VuiSpacer, VuiText, VuiTitle, VuiFormGroup, VuiTextInput } from "../ui";
+import {
+  VuiButtonPrimary,
+  VuiDrawer,
+  VuiLink,
+  VuiSpacer,
+  VuiText,
+  VuiTitle,
+  VuiFormGroup,
+  VuiTextInput,
+  VuiToggle
+} from "../ui";
 
 type Props = {
   isOpen: boolean;
@@ -11,6 +21,10 @@ type Props = {
   onUpdateApiKey: (event: React.ChangeEvent<HTMLInputElement>) => void;
   placeholder: string;
   onUpdatePlaceholder: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  isDeeplinkable: boolean;
+  onUpdateIsDeeplinkable: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  openResultsInNewTab: boolean;
+  onUpdateOpenResultsInNewTab: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 export const ConfigurationDrawer = ({
@@ -23,7 +37,11 @@ export const ConfigurationDrawer = ({
   apiKey,
   onUpdateApiKey,
   placeholder,
-  onUpdatePlaceholder
+  onUpdatePlaceholder,
+  isDeeplinkable,
+  onUpdateIsDeeplinkable,
+  openResultsInNewTab,
+  onUpdateOpenResultsInNewTab
 }: Props) => {
   return (
     <VuiDrawer
@@ -68,7 +86,7 @@ export const ConfigurationDrawer = ({
         <VuiTextInput value={apiKey} onChange={onUpdateApiKey} fullWidth />
       </VuiFormGroup>
 
-      <VuiSpacer size="m" />
+      <VuiSpacer size="l" />
 
       <VuiTitle size="s">
         <h3 className="header">Customize appearance</h3>
@@ -78,6 +96,24 @@ export const ConfigurationDrawer = ({
 
       <VuiFormGroup label="Placeholder text" labelFor="placeholderText">
         <VuiTextInput value={placeholder} onChange={onUpdatePlaceholder} fullWidth />
+      </VuiFormGroup>
+
+      <VuiSpacer size="l" />
+
+      <VuiTitle size="s">
+        <h3 className="header">Customize behavior</h3>
+      </VuiTitle>
+
+      <VuiSpacer size="s" />
+
+      <VuiFormGroup label="Allow deeplinking" labelFor="isDeepLinkable">
+        <VuiToggle checked={isDeeplinkable} onChange={onUpdateIsDeeplinkable} id="isDeeplinkable" />
+      </VuiFormGroup>
+
+      <VuiSpacer size="xs" />
+
+      <VuiFormGroup label="Open results in a new tab" labelFor="openResultsInNewTab">
+        <VuiToggle checked={openResultsInNewTab} onChange={onUpdateOpenResultsInNewTab} id="openResultsInNewTab" />
       </VuiFormGroup>
 
       <VuiSpacer size="l" />


### PR DESCRIPTION
## CONTEXT
We need to add toggles for the `isDeeplinkable` and `openResultsInNewTab` props in the docs page configuration editor.

We can also assist devs a bit more by ensuring the code snippet correctly reflects what they enter in the configuration editor. This works really well with the copy button that already accompanies the code snippet and removes friction associated with having to change values they've already tested on the page.

## CHANGES
- add toggles for two new props
- update the code snippet to reflect config editor values.

## SCREENSHOTS
![snippet_live_edit](https://github.com/vectara/react-search/assets/1464245/dda413ed-1633-41a9-90e4-1d280a659875)
