### PR TITLE
chore: add x-source to request headers

### DIFF
--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -72,7 +72,7 @@ const generateCodeSnippet = (
 const DEFAULT_CORPUS_ID = "1";
 const DEFAULT_CUSTOMER_ID = "1366999410";
 const DEFAULT_API_KEY = "zqt_UXrBcnI2UXINZkrv4g1tQPhzj02vfdtqYJIDiA";
-const DEFAULT_PLACEHOLDER = 'Try searching for "vectara" or "grounded generation"';
+const DEFAULT_PLACEHOLDER = 'Try searching for "vectara" or "RAG"';
 
 const App = () => {
   const [isConfigurationDrawerOpen, setIsConfigurationDrawerOpen] = useState(false);

--- a/src/useSearch.tsx
+++ b/src/useSearch.tsx
@@ -21,6 +21,7 @@ export const useSearch = (
     headersInstance.append("customer-id", customerId);
     headersInstance.append("x-api-key", apiKey);
     headersInstance.append("content-type", "application/json");
+    headersInstance.append("x-source", "react-search");
 
     return headersInstance;
   }, [customerId, apiKey]);


### PR DESCRIPTION
## CONTEXT
This change has been pending for a while. :)
This adds x-source to the request headers so we can track usage of search on the front end.

## CHANGES
- add `x-source` to the API request headers
- small change: change default placeholder to refer to "RAG" instead of "grounded generation"
