### PR TITLE
feat: Add modal close button for small screens

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14,7 +14,7 @@
     },
     "..": {
       "name": "@vectara/react-search",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@testing-library/react-hooks": "^8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/react-search",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/react-search",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@testing-library/react-hooks": "^8.0.1",

--- a/src/SearchInput.tsx
+++ b/src/SearchInput.tsx
@@ -11,18 +11,20 @@ type Props = {
 
 export const SearchInput = ({ value, onChange, placeholder, autoFocus, onSubmit, ...rest }: Props) => {
   return (
-    <input
-      data-testid="searchInput"
-      className="vrsSearchInput"
-      type="text"
-      autoComplete="off"
-      autoCapitalize="off"
-      spellCheck="false"
-      autoFocus={autoFocus}
-      placeholder={placeholder}
-      value={value}
-      onChange={onChange}
-      {...rest}
-    />
+    <>
+      <input
+        data-testid="searchInput"
+        className="vrsSearchInput"
+        type="text"
+        autoComplete="off"
+        autoCapitalize="off"
+        spellCheck="false"
+        autoFocus={autoFocus}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        {...rest}
+      />
+    </>
   );
 };

--- a/src/SearchInput.tsx
+++ b/src/SearchInput.tsx
@@ -11,20 +11,18 @@ type Props = {
 
 export const SearchInput = ({ value, onChange, placeholder, autoFocus, onSubmit, ...rest }: Props) => {
   return (
-    <>
-      <input
-        data-testid="searchInput"
-        className="vrsSearchInput"
-        type="text"
-        autoComplete="off"
-        autoCapitalize="off"
-        spellCheck="false"
-        autoFocus={autoFocus}
-        placeholder={placeholder}
-        value={value}
-        onChange={onChange}
-        {...rest}
-      />
-    </>
+    <input
+      data-testid="searchInput"
+      className="vrsSearchInput"
+      type="text"
+      autoComplete="off"
+      autoCapitalize="off"
+      spellCheck="false"
+      autoFocus={autoFocus}
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+      {...rest}
+    />
   );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -237,7 +237,24 @@ const ReactSearchInternal: FC<Props> = ({
         <SearchModal isOpen={isOpen} onClose={closeModalAndResetResults}>
           <form>
             <div className="vrsSearchForm">
-              <SearchInput value={searchValue} onChange={onChange} onKeyDown={onKeyDown} placeholder={placeholder} />
+              <div className="vrsCloseButtonWrapper">
+                <button
+                  className="vrsSubmitButton"
+                  onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                    e.preventDefault();
+                    closeModalAndResetResults();
+                  }}
+                >
+                  <CloseIcon size="12px" />
+                </button>
+              </div>
+              <SearchInput
+                value={searchValue}
+                onChange={onChange}
+                onKeyDown={onKeyDown}
+                placeholder={placeholder}
+                autoFocus={true}
+              />
               {isLoading ? (
                 <div className="vrsSubmitButtonWrapper">
                   <VuiSpinner size="xs" />
@@ -288,6 +305,12 @@ const SearchIcon = () => (
       </g>
     </svg>
   </div>
+);
+
+export const CloseIcon = ({ size }: { size: string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 329.26933 329" width={size} height={size} fill="currentColor">
+    <path d="m194.800781 164.769531 128.210938-128.214843c8.34375-8.339844 8.34375-21.824219 0-30.164063-8.339844-8.339844-21.824219-8.339844-30.164063 0l-128.214844 128.214844-128.210937-128.214844c-8.34375-8.339844-21.824219-8.339844-30.164063 0-8.34375 8.339844-8.34375 21.824219 0 30.164063l128.210938 128.214843-128.210938 128.214844c-8.34375 8.339844-8.34375 21.824219 0 30.164063 4.15625 4.160156 9.621094 6.25 15.082032 6.25 5.460937 0 10.921875-2.089844 15.082031-6.25l128.210937-128.214844 128.214844 128.214844c4.160156 4.160156 9.621094 6.25 15.082032 6.25 5.460937 0 10.921874-2.089844 15.082031-6.25 8.34375-8.339844 8.34375-21.824219 0-30.164063zm0 0" />
+  </svg>
 );
 
 class ReactSearchWebComponent extends HTMLElement {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -240,6 +240,7 @@ const ReactSearchInternal: FC<Props> = ({
               <div className="vrsCloseButtonWrapper">
                 <button
                   className="vrsSubmitButton"
+                  aria-label="Close"
                   onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                     e.preventDefault();
                     closeModalAndResetResults();

--- a/src/searchInput.scss
+++ b/src/searchInput.scss
@@ -18,6 +18,11 @@
   color: $colorText;
 }
 
+.vrsCloseButtonWrapper {
+  display: none;
+  padding-left: $sizeM;
+}
+
 .vrsSubmitButtonWrapper {
   padding-right: $sizeM;
 }
@@ -29,5 +34,11 @@
 
   &:hover {
     color: $colorPrimary;
+  }
+}
+
+@media only screen and (max-width: 740px) {
+  .vrsCloseButtonWrapper {
+    display: initial;
   }
 }


### PR DESCRIPTION
## CONTEXT
The search modal cannot be closed on small screens if there are search results showing, so we need to add one for that form factor.

_The design takes inspiration from Google's mobile search:_
<img src="https://github.com/vectara/react-search/assets/1464245/a1904b09-4fd4-4d43-8d1b-0f49dbe3f0fb" width=400></img>


## CHANGES
- Add a close button next to the search input

## SCREENSHOTS

### BEFORE
<img width="495" alt="Screenshot 2024-03-14 at 3 18 15 PM" src="https://github.com/vectara/react-search/assets/1464245/4cd71adc-14c3-4673-81f1-3c20a4a7d342">


### AFTER
<img width="493" alt="Screenshot 2024-03-14 at 3 18 30 PM" src="https://github.com/vectara/react-search/assets/1464245/a8ba9183-b749-4e4d-8509-60e4506f8a87">



