### PR TITLE
fix: add missing position property to z-indexed container

### DIFF
--- a/buildConfigs.js
+++ b/buildConfigs.js
@@ -17,7 +17,14 @@ const sharedConfig = {
 
   // css-text outputs CSS as a string which can be embedded as a stylesheet in a web component
   // See for more info: https://github.com/glromeo/esbuild-sass-plugin?tab=readme-ov-file#type-css-text
-  plugins: [cssPlugin(), sassPlugin({ type: "css-text" })],
+  plugins: [
+    cssPlugin(),
+    sassPlugin({
+      filter: /globals\.scss$/,
+      type: "style"
+    }),
+    sassPlugin({ type: "css-text" })
+  ],
   outdir: "./lib",
   outbase: "./src"
 };

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14,7 +14,7 @@
     },
     "..": {
       "name": "@vectara/react-search",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@testing-library/react-hooks": "^8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/react-search",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/react-search",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@testing-library/react-hooks": "^8.0.1",

--- a/src/SearchModal.tsx
+++ b/src/SearchModal.tsx
@@ -39,25 +39,23 @@ export const SearchModal = forwardRef(
 
     return (
       <VuiPortal>
-        <div className="vrsStyleWrapper">
-          {isOpen && (
-            <div style={{ zIndex }}>
-              <VuiScreenBlock>
-                <FocusOn
-                  onEscapeKey={onCloseDelayed}
-                  onClickOutside={onCloseDelayed}
-                  // Enable manual focus return to work.
-                  returnFocus={false}
-                  // Enable focus on contents when it's open,
-                  // but enable manual focus return to work when it's closed.
-                  autoFocus={isOpen}
-                >
-                  <SearchModalContents ref={ref}>{children}</SearchModalContents>
-                </FocusOn>
-              </VuiScreenBlock>
-            </div>
-          )}
-        </div>
+        {isOpen && (
+          <div className="vrsModalWrapper" style={{ zIndex }}>
+            <VuiScreenBlock>
+              <FocusOn
+                onEscapeKey={onCloseDelayed}
+                onClickOutside={onCloseDelayed}
+                // Enable manual focus return to work.
+                returnFocus={false}
+                // Enable focus on contents when it's open,
+                // but enable manual focus return to work when it's closed.
+                autoFocus={isOpen}
+              >
+                <SearchModalContents ref={ref}>{children}</SearchModalContents>
+              </FocusOn>
+            </VuiScreenBlock>
+          </div>
+        )}
       </VuiPortal>
     );
   }

--- a/src/_index.scss
+++ b/src/_index.scss
@@ -21,11 +21,6 @@ button {
   font-size: inherit;
 }
 
-.vrsStyleWrapper {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
-    "Droid Sans", "Helvetica Neue", sans-serif;
-}
-
 .vrsSearchButton {
   display: flex;
   width: 100%;

--- a/src/globals.scss
+++ b/src/globals.scss
@@ -1,0 +1,7 @@
+@import "./vui/styleUtils/_colors";
+@import "./vui/styleUtils/_depth";
+@import "./vui/components/screenBlock/index";
+
+.vrsModalWrapper {
+  position: fixed;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ import { useSearchHistory } from "./useSearchHistory";
 
 // @ts-ignore
 import cssText from "./_index.scss";
+import "./globals.scss";
 
 import { SearchInput } from "./SearchInput";
 
@@ -208,7 +209,7 @@ const ReactSearchInternal: FC<Props> = ({
 
   return (
     <>
-      <div className="vrsStyleWrapper">
+      <div>
         <div ref={buttonRef}>
           <button className="vrsSearchButton" onClick={() => setIsOpen(true)}>
             <VuiFlexContainer


### PR DESCRIPTION
## CONTEXT
The added `z-index` CSS to the modal wrapper will not take effect if the position is `static` (which is the default, in this case). To fix this, we need to add a `position` property that is compatible with `z-index`.

This property was in originally part of https://github.com/vectara/react-search/pull/56 but was mistakenly reverted.

## CHANGES
- add `position: fixed` to z-indexed wrapper div since the modal itself is in fixed position