### PR TITLE
feat: Add support for reranking configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ import { ReactSearch } from "@vectara/react-search";
   openResultsInNewTab={true} // Optional boolean determining if links will open in a new tab
   zIndex={1000} // Optional number assigned to the z-index of the search modal
   isSummaryToggleVisible={true} // Optional boolean determining if users can summarize search results
+  rerankingConfiguration={{
+    rerankerId: 272725718
+  }}
 />;
 ```
 
@@ -106,7 +109,12 @@ Whether users will be able to summarize search results or not.
 
 ##### `isSummaryToggleInitiallyEnabled` (optional)
 
-If users can toggle summarization, whether the toggle should be enabled by defualt.
+If users can toggle summarization, whether the toggle should be enabled by default.
+
+##### `rerankingConfiguration` (optional)
+
+Specifies a search result reranker to use, along with its configuration.
+For more information, see our [docs on reranking](https://docs.vectara.com/docs/api-reference/search-apis/reranking).
 
 ### Power your own search UI with the useSearch hook
 
@@ -123,7 +131,13 @@ import { useSearch } from "@vectara/react-search/lib/useSearch";
 
 /* snip */
 
-const { fetchSearchResults, isLoading } = useSearch("CUSTOMER_ID", "CORPUS_ID", "API_KEY");
+const { fetchSearchResults, isLoading } = useSearch(
+  "CUSTOMER_ID",
+  "CORPUS_ID",
+  "API_KEY",
+  "API_URL", // optional
+  { rerankerId: 12345 } // optional
+);
 ```
 
 The values returned by the hook can be passed on to your custom components as props or used in any way you wish.

--- a/docs/src/components/ConfigurationDrawer.tsx
+++ b/docs/src/components/ConfigurationDrawer.tsx
@@ -1,3 +1,4 @@
+import { RerankingConfiguration } from "../../../lib/types";
 import {
   VuiButtonPrimary,
   VuiDrawer,
@@ -7,7 +8,8 @@ import {
   VuiTitle,
   VuiFormGroup,
   VuiTextInput,
-  VuiToggle
+  VuiToggle,
+  VuiTextArea
 } from "../ui";
 
 type Props = {
@@ -31,6 +33,8 @@ type Props = {
   setIsSummaryToggleVisible: (isSummaryToggleVisible: boolean) => void;
   isSummaryToggleInitiallyEnabled: boolean;
   setIsSummaryToggleInitiallyEnabled: (isSummaryToggleInitiallyEnabled: boolean) => void;
+  rerankingConfigurationString?: string;
+  setRerankingConfigurationString: (configurationString: string) => void;
 };
 
 export const ConfigurationDrawer = ({
@@ -53,8 +57,16 @@ export const ConfigurationDrawer = ({
   isSummaryToggleVisible,
   setIsSummaryToggleVisible,
   isSummaryToggleInitiallyEnabled,
-  setIsSummaryToggleInitiallyEnabled
+  setIsSummaryToggleInitiallyEnabled,
+  rerankingConfigurationString,
+  setRerankingConfigurationString
 }: Props) => {
+  const rerankingConfigPlaceholder = `{
+  "rerankerId": 272725718,
+  "mmrConfig": {
+    "diversityBias": 0
+  }
+}`;
   return (
     <VuiDrawer
       color="primary"
@@ -165,6 +177,24 @@ export const ConfigurationDrawer = ({
           checked={isSummaryToggleInitiallyEnabled}
           onChange={(e) => setIsSummaryToggleInitiallyEnabled(e.target.checked)}
           id="summaryToggleInitiallyEnabled"
+        />
+      </VuiFormGroup>
+
+      <VuiSpacer size="l" />
+
+      <VuiTitle size="s">
+        <h3 className="header">Reranking</h3>
+      </VuiTitle>
+
+      <VuiSpacer size="s" />
+
+      <VuiFormGroup label="Reranking Configuration" labelFor="rerankingConfiguration">
+        <VuiTextArea
+          fullWidth={true}
+          placeholder={rerankingConfigPlaceholder}
+          value={rerankingConfigurationString}
+          onChange={(e) => setRerankingConfigurationString(e.target.value)}
+          id="rerankingConfiguration"
         />
       </VuiFormGroup>
 

--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -21,6 +21,7 @@ import { HeaderLogo } from "./components/HeaderLogo";
 import { ConfigurationDrawer } from "components/ConfigurationDrawer";
 import "./ui/_index.scss";
 import "./index.scss";
+import { RerankingConfiguration } from "@vectara/react-search/lib/types";
 
 const generateCodeSnippet = ({
   customerId,
@@ -31,7 +32,8 @@ const generateCodeSnippet = ({
   openResultsInNewTab = false,
   isOnToggleSummaryHandled = false,
   isSummaryToggleVisible = false,
-  isSummaryToggleInitiallyEnabled = false
+  isSummaryToggleInitiallyEnabled = false,
+  rerankingConfiguration
 }: {
   customerId?: string;
   corpusId?: string;
@@ -42,6 +44,7 @@ const generateCodeSnippet = ({
   isOnToggleSummaryHandled: boolean;
   isSummaryToggleVisible: boolean;
   isSummaryToggleInitiallyEnabled: boolean;
+  rerankingConfiguration?: RerankingConfiguration;
 }) => {
   let quotedPlaceholder = placeholder;
 
@@ -83,6 +86,10 @@ const generateCodeSnippet = ({
     props.push(`isSummaryToggleInitiallyEnabled={${isSummaryToggleInitiallyEnabled}}`);
   }
 
+  if (rerankingConfiguration) {
+    props.push(`rerankingConfiguration={${JSON.stringify(rerankingConfiguration)}}`);
+  }
+
   props.push(`zIndex={ /* (optional) number representing the z-index the search modal should have */ }`);
 
   return `import { ReactSearch } from "@vectara/react-search";
@@ -112,6 +119,15 @@ const App = () => {
   const [isOnToggleSummaryHandled, setIsOnToggleSummaryHandled] = useState<boolean>(false);
   const [isSummaryToggleVisible, setIsSummaryToggleVisible] = useState<boolean>(true);
   const [isSummaryToggleInitiallyEnabled, setIsSummaryToggleInitiallyEnabled] = useState<boolean>(true);
+  const [rerankingConfigurationString, setRerankingConfigurationString] = useState<string | undefined>(undefined);
+
+  let rerankingConfiguration;
+
+  try {
+    rerankingConfiguration = JSON.parse(rerankingConfigurationString ?? "");
+  } catch {
+    rerankingConfiguration = undefined;
+  }
 
   return (
     <>
@@ -182,6 +198,7 @@ const App = () => {
                 onToggleSummary={(isSummaryEnabled: boolean) =>
                   console.log(`onToggleSummary callback received isSummaryEnabled: ${isSummaryEnabled}`)
                 }
+                rerankingConfiguration={rerankingConfiguration}
               />
             </div>
 
@@ -224,7 +241,8 @@ const App = () => {
                 openResultsInNewTab,
                 isOnToggleSummaryHandled,
                 isSummaryToggleVisible,
-                isSummaryToggleInitiallyEnabled
+                isSummaryToggleInitiallyEnabled,
+                rerankingConfiguration
               })}
             </VuiCode>
 
@@ -304,6 +322,8 @@ export const App = () => {
               setIsSummaryToggleVisible={setIsSummaryToggleVisible}
               isSummaryToggleInitiallyEnabled={isSummaryToggleInitiallyEnabled}
               setIsSummaryToggleInitiallyEnabled={setIsSummaryToggleInitiallyEnabled}
+              rerankingConfigurationString={rerankingConfigurationString}
+              setRerankingConfigurationString={setRerankingConfigurationString}
             />
           </div>
         </VuiAppContent>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,7 +44,8 @@ const ReactSearchInternal = ({
   zIndex = 9999,
   onToggleSummary,
   isSummaryToggleVisible = false,
-  isSummaryToggleInitiallyEnabled = false
+  isSummaryToggleInitiallyEnabled = false,
+  rerankingConfiguration
 }: Props) => {
   // Compute a unique ID for this search component.
   // This creates a namespace, and ensures that stored search results
@@ -54,7 +55,7 @@ const ReactSearchInternal = ({
   // of different search boxes.
   const searchId = useMemo(() => getUuid(`${customerId}-${corpusId}-${apiKey}`), [customerId, corpusId, apiKey]);
   const { addPreviousSearch } = useSearchHistory(searchId, historySize);
-  const { fetchSearchResults, isLoading } = useSearch(customerId, corpusId, apiKey, apiUrl);
+  const { fetchSearchResults, isLoading } = useSearch(customerId, corpusId, apiKey, apiUrl, rerankingConfiguration);
 
   const [selectedResultIndex, setSelectedResultIndex] = useState<number>();
   const [searchResults, setSearchResults] = useState<DeserializedSearchResult[]>([]);
@@ -194,7 +195,10 @@ const ReactSearchInternal = ({
           } = searchResult;
 
           return (
-            <div ref={selectedResultIndex === index ? selectedResultRef : undefined} key={`${pre}${text}${post}`}>
+            <div
+              ref={selectedResultIndex === index ? selectedResultRef : undefined}
+              key={`result-${index}-${pre}${text}${post}`}
+            >
               <SearchResult
                 searchResult={searchResult}
                 isSelected={selectedResultIndex === index}

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,18 @@ export interface Props {
 
   // If users can toggle summarization, whether the toggle should be enabled by defualt.
   isSummaryToggleInitiallyEnabled?: boolean;
+
+  // The custom reranker configuration to use.
+  // For more information, see: https://docs.vectara.com/docs/api-reference/search-apis/reranking
+  rerankingConfiguration?: RerankingConfiguration;
 }
+
+export type RerankingConfiguration = {
+  rerankerId: number;
+  mmrConfig?: {
+    diversityBias: number;
+  };
+};
 
 export type DeserializedSearchResult = {
   id: string;

--- a/src/useSearch.test.ts
+++ b/src/useSearch.test.ts
@@ -11,11 +11,24 @@ describe("useSearch", () => {
       })
     );
 
-    const { result } = renderHook(() => useSearch("mock-customer-id", "mock-corpus-id", "mock-api-key"));
+    const { result } = renderHook(() =>
+      useSearch("mock-customer-id", "mock-corpus-id", "mock-api-key", undefined, {
+        rerankerId: 272725718,
+        mmrConfig: {
+          diversityBias: 0.3
+        }
+      })
+    );
     const requestBody = JSON.stringify({
       query: [
         {
           query: "mock-query",
+          rerankingConfig: {
+            rerankerId: 272725718,
+            mmrConfig: {
+              diversityBias: 0.3
+            }
+          },
           start: 0,
           numResults: 20,
           corpusKey: [

--- a/src/useSearch.ts
+++ b/src/useSearch.ts
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react";
-import { DeserializedSearchResult, DocMetadata, SearchResponse } from "./types";
+import { DeserializedSearchResult, DocMetadata, RerankingConfiguration, SearchResponse } from "./types";
 
 const DEFAULT_QUERY_API_URL = "https://api.vectara.io/v1/query";
 
@@ -12,7 +12,8 @@ export const useSearch = (
   customerId: string,
   corpusId: string,
   apiKey: string,
-  apiUrl: string = DEFAULT_QUERY_API_URL
+  apiUrl: string = DEFAULT_QUERY_API_URL,
+  rerankingConfig?: RerankingConfiguration
 ) => {
   const [isLoading, setIsLoading] = useState(false);
 
@@ -32,6 +33,9 @@ export const useSearch = (
         query: [
           {
             query,
+            rerankingConfig: {
+              ...rerankingConfig
+            },
             start: 0,
             numResults: 20,
             corpusKey: [
@@ -51,7 +55,7 @@ export const useSearch = (
         ]
       });
     },
-    [corpusId]
+    [corpusId, rerankingConfig]
   );
 
   const fetchSearchResults = async (


### PR DESCRIPTION
## CONTEXT
In order to make use of the new reranker, we'll need to accept reranking configs as a prop for the ReactSearch component, and as a param for the useSearch hook.

## CHANGES
- add `rerankingConfiguration` prop to ReactSearch
- add a rerankingConfig parameter to useSearch hook