### PR TITLE
Release 1.2.1

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,9 @@
 /src
 /docs
 /images
+/.github
+/.claude
+.prettierrc.json
 buildConfigs.js
 build.js
 global.d.ts
@@ -10,3 +13,4 @@ README.md
 tsconfig.json
 setupTests.ts
 jest.config.js
+lib/tsconfig.tsbuildinfo

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/react-search",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/react-search",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@testing-library/react-hooks": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectara/react-search",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A Vectara-powered Search component",
   "main": "lib/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
## Release 1.2.1

Published to npm: https://www.npmjs.com/package/@vectara/react-search/v/1.2.1

### Changes
- Bump version to \`1.2.1\`.
- Exclude local/dev config and build cache from the published npm tarball: \`.github/\`, \`.claude/\`, \`.prettierrc.json\`, and \`lib/tsconfig.tsbuildinfo\`. Previously these were being packaged (dry run showed \`.claude/settings.local.json\` and CI workflows leaking into the tarball).

The published tarball now contains only \`lib/\` (JS + type defs), \`package.json\`, \`README.md\`, and \`LICENSE\` (42 files).

Tag \`v1.2.1\` points at the exact published commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)